### PR TITLE
meshkit: If packages have been renamed/moved the API failed to build 

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -113,7 +113,7 @@ def wizard():
     # session.profiles = get_profiles(config.buildroots_dir, session.target, os.path.join(request.folder, "static", "ajax"))
     defaultpkgs = get_defaultpkgs(config.buildroots_dir, session.target, os.path.join(request.folder, "static", "ajax"))
     session.theme = config.defaulttheme
-    # generate a static package list (this is only done once.
+    # generate a static package list (this is only done once).
     # if package lists change delete the cache file in static/package_lists/<target>
     create_package_list(config.buildroots_dir, session.target, os.path.join(request.folder, "static", "package_lists"))
     user_packagelist = ''
@@ -292,6 +292,12 @@ def buildimage():
 
     if not request.vars.target:
         return {'errors': 'Required variable "target" is missing.'}
+
+    # apply some magic (rename packages that have been renamed/merged) so firmwareupdate.sh
+    # keeps working in this case
+    if request.vars.packages:
+        replacement_table = { 'luci-proto-6x4': 'luci-proto-ipv6' }
+        request.vars.packages = replace_obsolete_packages(os.path.join(request.folder, "static", "package_lists", request.vars.target), request.vars.packages, replacement_table)
 
     ret = db.imageconf.validate_and_insert(**request.vars)
     ret['rand'] = request.vars.rand

--- a/modules/meshkit.py
+++ b/modules/meshkit.py
@@ -269,3 +269,31 @@ def defip(mesh_network):
     ip_first=mesh_network.split("/")[0]
     octets=ip_first.split(".")
     return octets[0] + "." + octets[1] + "." + octets[2] + "." + str(int(octets[3]) + 1)
+
+def replace_obsolete_packages(available_packages_file, packages, rtable):
+    """Replaces packages in the package list that have been renamed or deleted
+
+    Args:
+        available_packages_file (string): Full path to the json-package list (static/package_lists/<target>)
+        packages (string): List of packages
+        rtable (dict): table containing what should be replaced with what
+    Returns:
+        string with replaced packages
+    """
+
+    if not available_packages_file or not packages or not rtable:
+        return False
+    else:
+        with open(available_packages_file, 'r') as f:
+            available_packages = json.load(f)
+            f.closed
+
+        for pkg in rtable:
+            has_pkg = False   
+            for key in available_packages:
+                if pkg in available_packages[key]:
+                    has_pkg = True
+
+            if not has_pkg:
+                packages = packages.replace(pkg, rtable[pkg])
+        return packages


### PR DESCRIPTION
...image when called from firmwareupgrade.sh on the router. This commit introduces a translation table to fix these package names

git-svn-id: http://svn.augsburg.freifunk.net/meshkit@788 c59f2a53-1f6a-49bd-a20d-d3124f46c12c
